### PR TITLE
Add proper doc strings; change Trace initialization

### DIFF
--- a/stompserver/stompserver.go
+++ b/stompserver/stompserver.go
@@ -155,22 +155,27 @@ func initStomp() {
 	log.Println(stompMgr.String())
 }
 
-// Define FWJR Record
+// MetaData defines FWJR Record
 type MetaData struct {
 	Ts      int64  `json:"ts"`
 	JobType string `json:"jobtype"`
 	WnName  string `json:"wn_name"`
 }
 
+// InputLst defines input structure
 type InputLst struct {
 	Lfn    int    `json:"lfn"`
 	Events int64  `json:"events"`
 	GUID   string `json:"guid"`
 }
+
+// Step defines step structure
 type Step struct {
 	Input []InputLst `json:"input"`
 	Site  string     `json:"site"`
 }
+
+// FWJRRecord defines fwjr record structure
 type FWJRRecord struct {
 	LFNArray      []string
 	LFNArrayRef   []string
@@ -258,21 +263,21 @@ func FWJRconsumer(msg *stomp.Message) ([]Lfnsite, int64, string, string, error) 
 
 // NewTrace create new instance of Trace
 func NewTrace(lfn string, site string, ts int64, jobtype string, wnname string) Trace {
-	trc := Trace{}
-	trc.Account = "fwjr"
-	trc.ClientState = "DONE"
-	trc.Filename = lfn
-	trc.DID = "cms:" + fmt.Sprintf("%v", trc.Filename)
-	trc.EventType = "get"
-	trc.EventVersion = "API_1.21.6"
-	trc.FileReadts = ts
-	trc.Jobtype = jobtype
-	trc.RemoteSite = site
-	trc.Scope = "cms"
-	trc.Timestamp = trc.FileReadts
-	trc.TraceTimeentryUnix = trc.FileReadts
-	trc.Usrdn = "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=yuyi/CN=639751/CN=Yuyi Guo/CN=706639693"
-	trc.Wnname = wnname
+	trc := Trace{
+		Account:            "fwjr",
+		ClientState:        "DONE",
+		Filename:           lfn,
+		DID:                fmt.Sprintf("cms: %s", trc.Filename),
+		EventType:          "get",
+		EventVersion:       "API_1.21.6",
+		FileReadts:         ts,
+		RemoteSite:         site,
+		Scope:              "cms",
+		Timestamp:          trc.FileReadts,
+		TraceTimeentryUnix: trc.FileReadts,
+		Usrdn:              "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=yuyi/CN=639751/CN=Yuyi Guo/CN=706639693",
+		Wnname:             wnname,
+	}
 	return trc
 }
 

--- a/stompserver/stompserver.go
+++ b/stompserver/stompserver.go
@@ -8,7 +8,7 @@ package main
 // Process them, then produce a Ruci trace message and then it to topic:
 // /topic/cms.rucio.tracer
 //
-// Author: Yuyi Guo
+// Authors: Yuyi Guo and Valentin Kuznetsov
 // Created: Feb 2021
 
 import (


### PR DESCRIPTION
@yuyiguo , In GoLang all types, structs, function which starts with Upper case letter should be properly documented. For that there is a convention to use a doc string before such type, struct, function. Then, these doc strings can be used for auto-doc generation (simiar to Sphynx in Python). So far I added all doc strings to your types.

I also adjusted initialization of Trace object.

These are minor changes but eventually it makes code clean and documented. There are additional comments required at all your structures which can be used by auto doc generation.

I suggest that you look at `http.Request` docs for structs, see it [here](https://golang.org/pkg/net/http/#Request) and compare it to what you get from command line as you type `go doc http.Request`. As you will see they are the same. Therefore, if you properly type comments in your structs, and codebase, then go doc can generate nice documentation.

Also, I corrected author string. I contributed to this code already a lot and it should be properly acknowledged.